### PR TITLE
Replaces the tutor url to edly.io/tutor

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -53,7 +53,7 @@ class SiteFooter extends React.Component {
               <ul className="logo-list">
                 <li>{intl.formatMessage(messages['footer.poweredby.text'])}</li>
                 <li>
-                  <a href="https://docs.tutor.overhang.io" rel="noreferrer" target="_blank">
+                  <a href="https://edly.io/tutor/" rel="noreferrer" target="_blank">
                     <Image
                       src={`${config.LMS_BASE_URL}/static/indigo/images/tutor-logo.png`}
                       alt={intl.formatMessage(messages['footer.tutorlogo.altText'])}

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -22,7 +22,7 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
           </li>
           <li>
             <a
-              href="https://docs.tutor.overhang.io"
+              href="https://edly.io/tutor/"
               rel="noreferrer"
               target="_blank"
             >
@@ -120,7 +120,7 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
           </li>
           <li>
             <a
-              href="https://docs.tutor.overhang.io"
+              href="https://edly.io/tutor/"
               rel="noreferrer"
               target="_blank"
             >
@@ -180,7 +180,7 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
           </li>
           <li>
             <a
-              href="https://docs.tutor.overhang.io"
+              href="https://edly.io/tutor/"
               rel="noreferrer"
               target="_blank"
             >


### PR DESCRIPTION
Replacing tutor logo 'docs link' with 'edly.io/tutor'