### PR TITLE
fix: Add visible titles to image-based links

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -53,6 +53,7 @@ class SiteFooter extends React.Component {
             className="d-block"
             href={config.LMS_BASE_URL}
             aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
+            title={intl.formatMessage(messages['footer.logo.ariaLabel'])}
           >
             <img
               style={{ maxHeight: 45 }}

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -12,6 +12,7 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
       aria-label="edX Home"
       className="d-block"
       href="http://localhost:18000"
+      title="edX Home"
     >
       <img
         alt="Powered by Open edX"
@@ -80,6 +81,7 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
       aria-label="edX Home"
       className="d-block"
       href="http://localhost:18000"
+      title="edX Home"
     >
       <img
         alt="Powered by Open edX"
@@ -110,6 +112,7 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
       aria-label="edX Home"
       className="d-block"
       href="http://localhost:18000"
+      title="edX Home"
     >
       <img
         alt="Powered by Open edX"


### PR DESCRIPTION
### Description

This pull request resolves several accessibility issues in the Tutor Indigo theme that were identified during a recent accessibility review. These updates aim to improve usability for all users, especially those relying on assistive technologies. The changes also help ensure compliance with recognized accessibility standards, such as the Web Content Accessibility Guidelines (WCAG) 2.1.

For further details, please refer to the related issue: [overhangio/tutor-indigo#146](https://github.com/overhangio/tutor-indigo/issues/146).

---

### Accessibility Fixes Implemented


#### Add Accessible Titles to Image-Based Links

This pull request improves accessibility by adding visible titles to image-based links throughout the Tutor Indigo theme. Previously, these links lacked text descriptions, making them difficult to interpret for users relying on screen readers or keyboard navigation.

With this update, descriptive `title` attributes are added to each image-based link, providing additional context and enhancing the overall usability of the interface for all users.

- **Code Commit:** [fix: Add visible titles to image-based links](https://github.com/overhangio/tutor-indigo/commit/e7aaabf6d40f5dfa189a920a0a842513f4680794)
- **Issue:** [Taiga - US/79](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/79)
- **Live Example:** [Home Page](https://sandbox.openedx.edly.io/)
- **Linked Pull Requests:** [MFE Header](https://github.com/edly-io/frontend-component-header/pull/28) - [Tutor Indigo](https://github.com/overhangio/tutor-indigo/pull/150)

---

### Accessibility Audit Report

For the full audit and issue breakdown, please refer to the following report:  [Accessibility Audit](https://github.com/overhangio/tutor-indigo/issues/146)


